### PR TITLE
Use tutorial-6th image for base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM chemowakate/tutorial-env
+FROM chemowakate/tutorial-6th
 
 USER root
 RUN apt-get update \


### PR DESCRIPTION
RDKitがnumpyのバージョンの問題で起動しないので、
tutorial-6thのイメージをベースにするよう変更しました。